### PR TITLE
Support testnet currencies and add Kolibri

### DIFF
--- a/src/lib/thanos/assets.ts
+++ b/src/lib/thanos/assets.ts
@@ -18,6 +18,19 @@ export const XTZ_ASSET: ThanosAsset = {
   default: true,
 };
 
+export const TESTNET_TOKENS: ThanosToken[] = [
+  {
+    type: ThanosAssetType.FA1_2,
+    address: "KT1M9ThoXP9uGaUD7MvHKMbHqtj5i9VndHog",
+    name: "Kolibri",
+    symbol: "kUSD",
+    decimals: 18,
+    fungible: true,
+    iconUrl: "https://kolibri-data.s3.amazonaws.com/logo.png",
+    default: true,
+  } 
+]
+
 export const MAINNET_TOKENS: ThanosToken[] = [
   {
     type: ThanosAssetType.FA1_2,

--- a/src/lib/thanos/front/tokens.ts
+++ b/src/lib/thanos/front/tokens.ts
@@ -10,8 +10,14 @@ import {
   mergeAssets,
   omitAssets,
   MAINNET_TOKENS,
+  TESTNET_TOKENS,
 } from "lib/thanos/front";
 import { t } from "lib/i18n/react";
+
+const networkTokenMap = {
+  "main": MAINNET_TOKENS,
+  "test": TESTNET_TOKENS
+}
 
 export function useTokens() {
   const network = useNetwork();
@@ -30,7 +36,7 @@ export function useTokens() {
   ]);
 
   const allTokens = React.useMemo(
-    () => mergeAssets(network.type === "main" ? MAINNET_TOKENS : [], tokens),
+    () => mergeAssets(networkTokenMap[network.type], tokens),
     [network.type, tokens]
   );
 


### PR DESCRIPTION
Greetings!

I'm working with @lyoungblood and @keefertaylor on an upcoming stablecoin built on Tezos - Kolibri.

We want to get this stablecoin data into Thanos so it can display the current holdings and whatnot, but right now we're not launched on main-net. I noticed that Thanos doesn't support any tokens on testnet (yet) so I figured I'd add that functionality, then also add in Kolibri's current testnet token address. 

All together it looks like this 
<kbd>
<img width="400" src="https://user-images.githubusercontent.com/1072598/102725602-ea40ee80-42e5-11eb-890a-683bce842569.png" /></kbd>

Let me know if you'd like to see any changes or anything and I'd be happy to accommodate! 

Thanks!
