### PR TITLE
Add wXTZ Support

### DIFF
--- a/src/lib/thanos/assets.ts
+++ b/src/lib/thanos/assets.ts
@@ -36,7 +36,7 @@ export const DELPHINET_TOKENS: ThanosToken[] = [
     symbol: "wXTZ",
     decimals: 6,
     fungible: true,
-    iconUrl: "",
+    iconUrl: "https://github.com/StakerDAO/wrapped-xtz/blob/dev/assets/wXTZ-token-FullColor.png?raw=true",
     default: true,
   },
 ];
@@ -81,7 +81,7 @@ export const MAINNET_TOKENS: ThanosToken[] = [
     symbol: "wXTZ",
     decimals: 6,
     fungible: true,
-    iconUrl: "",
+    iconUrl: "https://github.com/StakerDAO/wrapped-xtz/blob/dev/assets/wXTZ-token-FullColor.png?raw=true",
     default: true,
   },
 ];

--- a/src/lib/thanos/assets.ts
+++ b/src/lib/thanos/assets.ts
@@ -29,6 +29,16 @@ export const DELPHINET_TOKENS: ThanosToken[] = [
     iconUrl: "https://kolibri-data.s3.amazonaws.com/logo.png",
     default: true,
   },
+  {
+    type: ThanosAssetType.FA1_2,
+    address: "KT1TDHL9ipKL8WW3TMPvutbLh9uZBdY9BU59",
+    name: "Wrapped Tezos",
+    symbol: "wXTZ",
+    decimals: 6,
+    fungible: true,
+    iconUrl: "",
+    default: true,
+  },
 ];
 
 export const MAINNET_TOKENS: ThanosToken[] = [
@@ -62,6 +72,16 @@ export const MAINNET_TOKENS: ThanosToken[] = [
     fungible: true,
     iconUrl:
       "https://tzbtc.io/wp-content/uploads/2020/03/tzbtc_logo_single.svg",
+    default: true,
+  },
+  {
+    type: ThanosAssetType.wXTZ,
+    address: "KT1VYsVfmobT7rsMVivvZ4J8i3bPiqz12NaH",
+    name: "Wrapped Tezos",
+    symbol: "wXTZ",
+    decimals: 6,
+    fungible: true,
+    iconUrl: "",
     default: true,
   },
 ];
@@ -217,7 +237,7 @@ export async function fetchBalance(
         nat = await contract.views
           .getBalance(accountPkh)
           .read((tezos as any).lambdaContract);
-      } catch {}
+      } catch { }
 
       if (!nat || nat.isNaN()) {
         nat = new BigNumber(0);
@@ -236,7 +256,7 @@ export async function fetchBalance(
           .balance_of([{ owner: accountPkh, token_id: asset.id }])
           .read((tezos as any).lambdaContract);
         nat = response[0].balance;
-      } catch {}
+      } catch { }
 
       if (!nat || nat.isNaN()) {
         nat = new BigNumber(0);
@@ -274,15 +294,15 @@ export async function toTransferParams(
       const methodArgs =
         asset.type === ThanosAssetType.FA2
           ? [
-              [
-                {
-                  from_: fromPkh,
-                  txs: [
-                    { to_: toPkh, token_id: asset.id, amount: pennyAmount },
-                  ],
-                },
-              ],
-            ]
+            [
+              {
+                from_: fromPkh,
+                txs: [
+                  { to_: toPkh, token_id: asset.id, amount: pennyAmount },
+                ],
+              },
+            ],
+          ]
           : [fromPkh, toPkh, pennyAmount];
       return contact.methods.transfer(...methodArgs).toTransferParams();
 
@@ -351,4 +371,4 @@ export function toPenny(asset: ThanosAsset) {
   return new BigNumber(1).div(10 ** asset.decimals).toNumber();
 }
 
-export class NotMatchingStandardError extends Error {}
+export class NotMatchingStandardError extends Error { }

--- a/src/lib/thanos/types.ts
+++ b/src/lib/thanos/types.ts
@@ -118,6 +118,7 @@ export enum ThanosAssetType {
   XTZ = "XTZ",
   TzBTC = "TzBTC",
   Staker = "STAKER",
+  wXTZ = "WXTZ",
   FA1_2 = "FA1_2",
   FA2 = "FA2",
 }


### PR DESCRIPTION
Hi There!

[StakerDAO](https://www.stakerdao.com/) is launching a new token on Tezos called Wrapped Tezos. This asset is conforms the L1 collateral to the FA1.2 token standard and is backed 1:1 with XTZ. If you're curious about the asset, please see:  https://stakerdao.gitbook.io/stakerdao-faq-and-docs/wrapped-tezos-wxtz-faq-and-docs.

This PR introduces token support on Delphinet and Mainnet where we have deployments for Wrapped Tezos.

We were hoping you'd consider supporting the token natively in Thanos. 

Please let me know if you have any questions. 